### PR TITLE
Add interactive shell script for LLM demo

### DIFF
--- a/dataset_utils.py
+++ b/dataset_utils.py
@@ -1,0 +1,136 @@
+"""Utilities for turning the raw HTML cheatsheet into model-ready data.
+
+The repository ships a single ``dataset.txt`` file that contains a long list
+of HTML tags with short descriptions.  The goal of this module is to transform
+those loosely formatted notes into structured prompt/completion pairs that can
+be consumed by a language model fine-tuning pipeline.
+
+Two small steps are involved:
+
+``load_html_tag_dataset``
+    Reads ``dataset.txt`` (or another file following the same format) and
+    extracts ``(tag, description)`` tuples.  The helper is robust to
+    multi-line descriptions and gracefully skips headings or blank lines.
+
+``build_prompt_completion_pairs``
+    Converts the ``(tag, description)`` tuples into dictionaries that follow
+    the common prompt/completion JSONL convention used by many LLM training
+    utilities.
+
+Both helpers are lightweight and avoid pulling heavy dependencies so that they
+can be used in simple data preparation scripts and unit tests.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Iterable, List, MutableSequence, Sequence, Tuple
+
+__all__ = [
+    "load_html_tag_dataset",
+    "build_prompt_completion_pairs",
+    "save_prompt_completion_jsonl",
+]
+
+
+_TAG_PATTERN = re.compile(r"<[^>]+>")
+
+
+def _looks_like_tag_line(line: str) -> bool:
+    """Return ``True`` when ``line`` resembles an HTML tag declaration."""
+
+    if not line:
+        return False
+    return bool(_TAG_PATTERN.search(line))
+
+
+def load_html_tag_dataset(path: Path | str) -> List[Tuple[str, str]]:
+    """Parse ``dataset.txt`` into ``(tag, description)`` tuples.
+
+    Parameters
+    ----------
+    path:
+        Location of the text dataset.  Either a :class:`pathlib.Path` instance
+        or a plain string.
+
+    Returns
+    -------
+    list of tuple[str, str]
+        A list containing ``(tag, description)`` pairs.  Multi-line
+        descriptions are collapsed into a single whitespace-normalised string.
+    """
+
+    dataset_path = Path(path)
+    raw_lines = dataset_path.read_text(encoding="utf-8").splitlines()
+
+    pairs: List[Tuple[str, str]] = []
+    current_tag: str | None = None
+    description_lines: MutableSequence[str] = []
+
+    def flush_current() -> None:
+        nonlocal current_tag, description_lines
+        if current_tag and description_lines:
+            description = " ".join(part.strip() for part in description_lines)
+            # Normalise whitespace so that descriptions look tidy when fed to
+            # an LLM training pipeline.
+            description = " ".join(description.split())
+            pairs.append((current_tag, description))
+        current_tag = None
+        description_lines = []
+
+    for raw_line in raw_lines:
+        line = raw_line.strip()
+        if not line:
+            # Blank lines simply separate sections – flush accumulated text.
+            flush_current()
+            continue
+
+        if _looks_like_tag_line(line):
+            flush_current()
+            current_tag = line
+            continue
+
+        if current_tag is None:
+            # Skip headings or explanatory text that is not tied to a tag.
+            continue
+
+        description_lines.append(line)
+
+    # Capture the trailing pair (if any) once the loop finishes.
+    flush_current()
+    return pairs
+
+
+def build_prompt_completion_pairs(
+    pairs: Sequence[Tuple[str, str]],
+    *,
+    instruction: str = "Describe the HTML element",
+) -> List[dict[str, str]]:
+    """Turn ``(tag, description)`` tuples into prompt/completion dictionaries."""
+
+    results: List[dict[str, str]] = []
+    for tag, description in pairs:
+        prompt = f"{instruction} `{tag}`."
+        # Fine-tuning utilities such as the OpenAI JSONL format expect the
+        # completion to start with a leading space so that the model learns to
+        # separate the prompt from the answer.
+        completion = " " + description.strip()
+        results.append({"prompt": prompt, "completion": completion})
+    return results
+
+
+def save_prompt_completion_jsonl(
+    data: Iterable[dict[str, str]], path: Path | str
+) -> Path:
+    """Persist prompt/completion dictionaries as a JSONL file."""
+
+    target_path = Path(path)
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    with target_path.open("w", encoding="utf-8") as fh:
+        for record in data:
+            json.dump(record, fh, ensure_ascii=False)
+            fh.write("\n")
+    return target_path
+

--- a/llm_demo.py
+++ b/llm_demo.py
@@ -1,0 +1,123 @@
+"""Small script that demonstrates prompting an off-the-shelf LLM."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any, Sequence
+
+from dataset_utils import build_prompt_completion_pairs, load_html_tag_dataset
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a quick generation demo using a 🤗 Transformers text-generation "
+            "pipeline."
+        )
+    )
+    parser.add_argument(
+        "--dataset",
+        type=Path,
+        default=Path(__file__).with_name("dataset.txt"),
+        help="Dataset file that will be converted to prompts.",
+    )
+    parser.add_argument(
+        "--model",
+        default="distilgpt2",
+        help="Model identifier compatible with transformers.pipeline().",
+    )
+    parser.add_argument(
+        "--max-length",
+        type=int,
+        default=80,
+        help="Maximum length for generated text (in tokens).",
+    )
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help=(
+            "Prompt for manual inputs instead of showcasing prompts derived from "
+            "the dataset."
+        ),
+    )
+    return parser.parse_args()
+
+
+def choose_prompts(prompt_completion: Sequence[dict[str, str]]) -> list[str]:
+    """Pick a handful of prompts to showcase in the demo."""
+
+    examples = []
+    for example in prompt_completion[:3]:
+        examples.append(example["prompt"])
+    return examples
+
+
+def create_generator(model: str):
+    """Create a text-generation pipeline for the requested model."""
+
+    try:
+        from transformers import pipeline
+    except ImportError as exc:  # pragma: no cover - exercised manually.
+        raise SystemExit(
+            "transformers is required for this demo. Install it via "
+            "`pip install transformers torch` and run the script again."
+        ) from exc
+
+    return pipeline("text-generation", model=model)
+
+
+def generate_text(generator: Any, prompt: str, max_length: int) -> str:
+    """Generate a completion for the provided prompt using the pipeline."""
+
+    outputs = generator(prompt, max_length=max_length, num_return_sequences=1)
+    return outputs[0]["generated_text"]
+
+
+def run_dataset_demo(prompts: Sequence[str], generator: Any, max_length: int) -> None:
+    """Run the canned dataset demonstration."""
+
+    for prompt in prompts:
+        print("=" * 80)
+        print("Prompt:")
+        print(prompt)
+        print("\nGenerated:")
+        print(generate_text(generator, prompt, max_length))
+
+
+def run_interactive_session(generator: Any, max_length: int) -> None:
+    """Interactively prompt the user for text to feed to the LLM."""
+
+    print("Enter a prompt to generate a completion (press Ctrl-D to exit).")
+    while True:
+        try:
+            prompt = input("Prompt> ")
+        except EOFError:
+            print()  # Add a trailing newline for clean exits.
+            break
+
+        if not prompt.strip():
+            continue
+
+        print("\nGenerated:")
+        print(generate_text(generator, prompt, max_length))
+        print("=" * 80)
+
+
+def main() -> None:
+    args = parse_args()
+    generator = create_generator(args.model)
+
+    if args.interactive:
+        run_interactive_session(generator, args.max_length)
+        return
+
+    pairs = load_html_tag_dataset(args.dataset)
+    prompt_completion = build_prompt_completion_pairs(pairs)
+    prompts = choose_prompts(prompt_completion)
+    run_dataset_demo(prompts, generator, args.max_length)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/prepare_dataset.py
+++ b/prepare_dataset.py
@@ -1,0 +1,49 @@
+"""Command-line helper that converts ``dataset.txt`` into JSONL format."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from dataset_utils import (
+    build_prompt_completion_pairs,
+    load_html_tag_dataset,
+    save_prompt_completion_jsonl,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert the raw HTML cheatsheet into prompt/completion JSONL that "
+            "can be used for language-model fine-tuning."
+        )
+    )
+    parser.add_argument(
+        "input",
+        nargs="?",
+        default=Path(__file__).with_name("dataset.txt"),
+        type=Path,
+        help="Path to the source dataset (defaults to dataset.txt in the repo).",
+    )
+    parser.add_argument(
+        "output",
+        nargs="?",
+        default=Path("data/html_cheatsheet.jsonl"),
+        type=Path,
+        help="Destination for the generated JSONL file.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    pairs = load_html_tag_dataset(args.input)
+    prompt_completion = build_prompt_completion_pairs(pairs)
+    target_path = save_prompt_completion_jsonl(prompt_completion, args.output)
+    print(f"Wrote {len(prompt_completion)} prompt/completion pairs to {target_path}.")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/run_llm.sh
+++ b/run_llm.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+MODEL="distilgpt2"
+MAX_LENGTH=80
+DATASET="${SCRIPT_DIR}/dataset.txt"
+INTERACTIVE=1
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Options:
+  --model NAME          Hugging Face model identifier (default: ${MODEL}).
+  --max-length TOKENS   Maximum generation length (default: ${MAX_LENGTH}).
+  --dataset PATH        Dataset file for non-interactive demos.
+  --demo                Run the canned dataset demo instead of interactive mode.
+  --help                Show this help message.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model)
+      MODEL="$2"
+      shift 2
+      ;;
+    --max-length)
+      MAX_LENGTH="$2"
+      shift 2
+      ;;
+    --dataset)
+      DATASET="$2"
+      shift 2
+      ;;
+    --demo)
+      INTERACTIVE=0
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${INTERACTIVE}" -eq 1 ]]; then
+  exec python "${SCRIPT_DIR}/llm_demo.py" --model "${MODEL}" --max-length "${MAX_LENGTH}" --interactive
+else
+  exec python "${SCRIPT_DIR}/llm_demo.py" --model "${MODEL}" --max-length "${MAX_LENGTH}" --dataset "${DATASET}"
+fi
+

--- a/tests/test_dataset_utils.py
+++ b/tests/test_dataset_utils.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from dataset_utils import build_prompt_completion_pairs, load_html_tag_dataset
+
+
+class DatasetUtilsTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.dataset_path = Path(__file__).resolve().parent.parent / "dataset.txt"
+
+    def test_load_pairs_contains_known_entry(self) -> None:
+        pairs = load_html_tag_dataset(self.dataset_path)
+        mapping = dict(pairs)
+        self.assertIn("<html> </html>", mapping)
+        self.assertTrue(
+            mapping["<html> </html>"].lower().startswith("creates an html document")
+        )
+
+    def test_multiline_descriptions_are_collapsed(self) -> None:
+        pairs = load_html_tag_dataset(self.dataset_path)
+        mapping = dict(pairs)
+        key = "<select multiple name=? size=?> </select>"
+        self.assertIn(key, mapping)
+        self.assertIn(
+            "menu items visible before user needs to scroll",
+            mapping[key],
+        )
+
+    def test_prompt_completion_format(self) -> None:
+        pairs = load_html_tag_dataset(self.dataset_path)
+        prompt_completion = build_prompt_completion_pairs(pairs[:2])
+        self.assertEqual(len(prompt_completion), 2)
+        self.assertTrue(prompt_completion[0]["prompt"].startswith("Describe"))
+        self.assertTrue(prompt_completion[0]["completion"].startswith(" "))
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_llm_demo.py
+++ b/tests/test_llm_demo.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import unittest
+
+from llm_demo import choose_prompts, generate_text
+
+
+class DummyGenerator:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int, int]] = []
+
+    def __call__(self, prompt: str, max_length: int, num_return_sequences: int):
+        self.calls.append((prompt, max_length, num_return_sequences))
+        return [{"generated_text": f"reply to: {prompt}"}]
+
+
+class LLMDemoHelpersTestCase(unittest.TestCase):
+    def test_choose_prompts_returns_first_three(self) -> None:
+        prompts = choose_prompts(
+            [
+                {"prompt": "p0", "completion": ""},
+                {"prompt": "p1", "completion": ""},
+                {"prompt": "p2", "completion": ""},
+                {"prompt": "p3", "completion": ""},
+            ]
+        )
+        self.assertEqual(prompts, ["p0", "p1", "p2"])
+
+    def test_generate_text_uses_generator(self) -> None:
+        generator = DummyGenerator()
+        output = generate_text(generator, "Hello world", max_length=42)
+        self.assertEqual(output, "reply to: Hello world")
+        self.assertEqual(generator.calls, [("Hello world", 42, 1)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `llm_demo.py` with reusable helpers and an interactive mode for manual prompts
- add a `run_llm.sh` convenience script that defaults to interactive generation but can still run the canned demo
- cover the new helper logic with unit tests

## Testing
- python -m unittest discover -s tests
- bash run_llm.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68e2c8f7a6348320b62c0902d0598292