### PR TITLE
Refactor demo to source LLM from model module

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Test configuration helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- expose the HTML tag demo LLM from `model.py` while making TensorFlow optional for imports
- update `llm_demo.generate_text` to work with both model instances and callable generators
- add a pytest `conftest.py` so tests can import the project modules via the repository root

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e2d616cc8483208d77c7c33c50aea4